### PR TITLE
bdemeta: add pkg-config support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,5 +5,5 @@ python:
 install:
   - pip install mypy
 script:
-  - mypy -p bdemeta
+  - mypy -p bdemeta -m tests/cmake_parser
   - python3 -m unittest discover

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,7 +7,7 @@ build: off
 test_script:
   - set PATH=C:\Python36
   - python -m pip install mypy
-  - python -m mypy -p bdemeta
+  - python -m mypy -p bdemeta -m tests/cmake_parser
   - python -m unittest discover
 deploy: off
 

--- a/bdemeta/types.py
+++ b/bdemeta/types.py
@@ -7,13 +7,18 @@ from typing import Dict, Iterator, List, Optional, Sequence, Union
 Config = Dict[str, Union[List[Path], List[str], Dict[str, str]]]
 
 class Identification:
-    def __init__(self, type: str, path: Optional[Path] = None) -> None:
-        self.type = type
-        self.path = path
+    def __init__(self,
+                 type:    str,
+                 path:    Optional[Path] = None,
+                 package: Optional[str] = None) -> None:
+        self.type    = type
+        self.path    = path
+        self.package = package
 
     def __eq__(self, other: object) -> bool:
         if isinstance(other, Identification):
-            return (self.type, self.path) == (other.type, other.path)
+            return (self.type, self.path, self.package) == \
+                                        (other.type, other.path, other.package)
         else:
             return False
 
@@ -90,4 +95,9 @@ class CMake(Target):
 
     def path(self) -> str:
         return self._path
+
+class Pkg(Target):
+    def __init__(self, name: str, package: str) -> None:
+        Target.__init__(self, name, [])
+        self.package = package
 

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 
 setup(name='bdemeta',
-      version='0.26',
+      version='0.27',
       description='Build and test BDE-style code',
       url='https://github.com/frutiger/bdemeta',
       author='Masud Rahman',

--- a/tests/cmake_parser.py
+++ b/tests/cmake_parser.py
@@ -1,0 +1,103 @@
+# tests.cmake_parser
+
+import re
+
+from typing import List, TextIO, Tuple, Union, Iterator, Any
+
+Command = Tuple[str, List[str]]
+# Using 'Any' below as mypy does not allow recursive types :(
+IfNode = Tuple[List[str], List[Any], List[Any]]  # type: ignore
+Node   = List[Union[Command, IfNode]]
+
+def lex(input: TextIO) -> Iterator[Command]:
+    whitespace = re.compile('\s+')
+
+    parsing_item    = False
+    parsing_command = False
+    command, args   = '', []
+    while True:
+        char = input.read(1)
+        if char is '':
+            break
+        if whitespace.match(char):
+            if parsing_item:
+                if parsing_command:
+                    args.append('')
+                else:
+                    command += char
+            parsing_item = False
+        elif char == '(':
+            if parsing_command:
+                raise RuntimeError('Nested command')
+            args.append('')
+            parsing_command = True
+            parsing_item    = False
+        elif char == ')':
+            if not parsing_command:
+                raise RuntimeError('Unexpected ")"')
+            if args[-1] == '':
+                args = args[:-1]
+            yield command, args
+            command, args   = '', []
+            parsing_item    = False
+            parsing_command = False
+        else:
+            if parsing_command:
+                args[-1] += char
+            else:
+                command += char
+            parsing_item = True
+
+def partial_match(lhs: Command, rhs: Command) -> bool:
+    if lhs[0] != rhs[0]:
+        return False
+
+    return all(map(lambda x: x[0] == x[1], zip(lhs[1], rhs[1])))
+
+def find_command(commands: List[Command],
+                 command:  str,
+                 opt_args: None=None) -> Tuple[int, List[str]]:
+    args: List[str] = opt_args if opt_args is not None else []
+
+    candidates = []
+    for index, item in enumerate(commands):
+        if partial_match((command, args), item):
+            candidates.append((index, item[1]))
+
+    if len(candidates) == 0:
+        raise RuntimeError('Predicate ({}, {}) not found'.format(command,
+                                                                 args))
+    if len(candidates) > 1:
+        raise RuntimeError('Ambiguous predicate ({}, {}) yielded {}'.format(
+                                                                   command,
+                                                                   args,
+                                                                   candidates))
+    return candidates[0]
+
+def parse_if(predicate: List[str], commands: Iterator[Command]) -> IfNode:
+    true_branch:  Node = []
+    false_branch: Node = []
+
+    branch = true_branch
+    for command in commands:
+        if 'if' == command[0]:
+            branch.append(parse_if(command[1], commands))
+        elif 'else' == command[0]:
+            branch = false_branch
+        elif 'endif' == command[0]:
+            return (predicate, true_branch, false_branch)
+        else:
+            branch.append(command)
+    raise RuntimeError('if with unmatched endif')
+
+def parse(commands: Iterator[Command]) -> Node:
+    result: Node = []
+
+    for command in commands:
+        if 'if' == command[0]:
+            result.append(parse_if(command[1], commands))
+        else:
+            result.append(command)
+
+    return result
+

--- a/tests/test_cmake_parser.py
+++ b/tests/test_cmake_parser.py
@@ -1,0 +1,92 @@
+# tests.test_cmake_parser
+
+from unittest import TestCase
+
+from tests.cmake_parser import parse_if, parse
+
+def mk_cmd(command, *args):
+    return (command, list(args))
+
+def call_parse_if(predicate, *cmds):
+    return parse_if(predicate, iter(cmds))
+
+def call_parse(*cmds):
+    return parse(iter(cmds))
+
+class TestParseIf(TestCase):
+    def test_empty_if(self):
+        node = call_parse_if('check', mk_cmd('endif'))
+        assert(('check', [], []) == node)
+
+    def test_one_command(self):
+        add_lib = mk_cmd('add_library')
+        node    = call_parse_if('check', add_lib, mk_cmd('endif'))
+        assert(('check', [add_lib], []) == node)
+
+    def test_empty_with_empty_else(self):
+        node    = call_parse_if('check', mk_cmd('else'), mk_cmd('endif'))
+        assert(('check', [], []) == node)
+
+    def test_if_else(self):
+        add_lib = mk_cmd('add_library')
+        add_exe = mk_cmd('add_executable')
+        node    = call_parse_if('check',
+                                add_lib,
+                                mk_cmd('else'),
+                                add_exe,
+                                mk_cmd('endif'))
+        assert(('check', [add_lib], [add_exe]) == node)
+
+    def test_nested_if(self):
+        foo  = mk_cmd('foo')
+        bar  = mk_cmd('bar')
+        bam  = mk_cmd('bam')
+        baz  = mk_cmd('baz')
+        node = call_parse_if('check',
+                             foo,
+                             mk_cmd('if'),
+                             bar,
+                             mk_cmd('else'),
+                             bam,
+                             mk_cmd('endif'),
+                             baz,
+                             mk_cmd('endif'))
+        assert(('check', [foo, ([], [bar], [bam]), baz], []) == node)
+
+class TestParse(TestCase):
+    def test_empty(self):
+        node = call_parse()
+        assert([] == node)
+
+    def test_one_non_if_command(self):
+        add_lib = mk_cmd('add_library')
+        node    = call_parse(add_lib)
+        assert([add_lib] == node)
+
+    def test_two_non_if_commands(self):
+        add_lib = mk_cmd('add_library')
+        add_exe = mk_cmd('add_executable')
+        node    = call_parse(add_lib, add_exe)
+        assert([add_lib, add_exe] == node)
+
+    def test_command_with_if(self):
+        add_lib = mk_cmd('add_library')
+        add_exe = mk_cmd('add_executable')
+        node    = call_parse(add_lib,
+                             mk_cmd('if', 'c'),
+                             add_exe,
+                             mk_cmd('endif'))
+        assert([add_lib, (['c'], [add_exe], [])] == node)
+
+    def test_command_with_if_else(self):
+        add_lib = mk_cmd('add_library')
+        add_exe = mk_cmd('add_executable')
+        include = mk_cmd('include')
+        node    = call_parse(add_lib,
+                             mk_cmd('if', 'c'),
+                             add_exe,
+                             mk_cmd('else'),
+                             include,
+                             mk_cmd('endif'))
+        assert([add_lib, (['c'], [add_exe], [include])] == node)
+

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -3,7 +3,7 @@
 from os.path import join as pj
 from unittest import TestCase
 
-from bdemeta.types import Target, Package, Group, CMake
+from bdemeta.types import Target, Package, Group, CMake, Pkg
 
 class TestTarget(TestCase):
     def test_overrides_none(self):
@@ -120,4 +120,13 @@ class TestCMake(TestCase):
     def test_different_path(self):
         c = CMake('d', pj('path', 'c'))
         assert(pj('path', 'c') == c.path())
+
+class TestPkg(TestCase):
+    def test_name(self):
+        p = Pkg('p', None)
+        assert('p' == p.name)
+
+    def test_package_name(self):
+        p = Pkg(None, 'foo')
+        assert('foo' == p.package)
 


### PR DESCRIPTION
@tdoug870 can you try this out with `pkg-config` dependencies?  You need to update your configuration file to have a dictionary with the key `pkg_configs`, such that any target dependency name (e.g. as specified by a `.dep` file) is a key with the value corresponding to the `pkg-config` package name.