### PR TITLE
testing: use newlines for non-TTY

### DIFF
--- a/bdemeta/testing.py
+++ b/bdemeta/testing.py
@@ -66,10 +66,13 @@ def run_tests(stdout:      TextIO,
             if test_errors:
                 errors[test] = test_errors
 
-            columns  = get_columns()
-            message  = '\r' + ' ' * columns + '\r'
-            message += trim(status_format.format(**locals()), columns)
-            print(message, end='', file=stderr, flush=True)
+            columns = get_columns()
+            message = trim(status_format.format(**locals()), columns)
+            if stderr.isatty():
+                print('\r' + ' ' * columns + '\r', end='', file=stderr)
+                print(message, end='', file=stderr, flush=True)
+            else:
+                print(message, file=stderr, flush=True)
     print(file=stderr, flush=True)
 
     for test, test_errors in errors.items():

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 
 setup(name='bdemeta',
-      version='0.41',
+      version='0.42',
       description='Build and test BDE-style code',
       url='https://github.com/frutiger/bdemeta',
       author='Masud Rahman',

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -2,6 +2,7 @@
 
 import io
 from unittest import TestCase
+from unittest import mock
 
 from bdemeta.testing import trim, run_one, RunResult, run_tests, MockRunner
 
@@ -111,7 +112,6 @@ class TestRun(TestCase):
         rc = run_tests(stdout, stderr, runner, lambda: 80, [["foo", "foo"]])
         assert(0 == rc)
 
-        assert('\n' not in stderr.getvalue()[:-1])
         assert('foo' in stderr.getvalue())
 
     def test_single_failure(self):
@@ -122,7 +122,6 @@ class TestRun(TestCase):
         rc = run_tests(stdout, stderr, runner, lambda: 80, [["foo", "foo"]])
         assert(1 == rc)
 
-        assert('\n' not in stderr.getvalue()[:-1])
         assert('foo' in stderr.getvalue())
 
         failures = stdout.getvalue().split('\n')[:-1]
@@ -141,7 +140,6 @@ class TestRun(TestCase):
                        [["foo", "foo"], ["bar", "bar"]])
         assert(0 == rc)
 
-        assert('\n' not in stderr.getvalue()[:-1])
         assert('foo' in stderr.getvalue())
         assert('bar' in stderr.getvalue())
 
@@ -157,7 +155,6 @@ class TestRun(TestCase):
                        [["foo", "foo"], ["bar", "bar"]])
         assert(1 == rc)
 
-        assert('\n' not in stderr.getvalue()[:-1])
         assert('foo' in stderr.getvalue())
         assert('bar' in stderr.getvalue())
 
@@ -168,3 +165,12 @@ class TestRun(TestCase):
         assert('FAIL TEST bar CASE 2' in failures)
         assert('FAIL TEST bar CASE 4' in failures)
 
+    def test_tty_has_no_newlines(self):
+        stdout = io.StringIO()
+        stderr = mock.Mock(wraps=io.StringIO())
+        stderr.isatty.return_value = True
+        runner = MockRunner('s')
+
+        rc = run_tests(stdout, stderr, runner, lambda: 80, [["foo", "foo"]])
+        assert(0 == rc)
+        assert('\n' not in stderr.getvalue()[:-1])


### PR DESCRIPTION
This ensures non-interactive users see well-formatted output from test
results.