### PR TITLE
types, resolver, cmake: support plugin tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,8 @@ follows:
         "extra_dependencies": {
             "<target7>": ["<target8>", "<target9>", ...],
             ...
-        }
+        },
+        "plugin_tests": ["<target10>", "<target11>", ...]
     }
 
 The meaning of each block is explained below.
@@ -146,6 +147,18 @@ dependencies that `bdemeta` is expected to resolve.  Since `bdemeta` does not
 parse CMake files, it needs to be informed about such dependencies.  The
 `extra_dependencies` block introduces a dependency from `<target7>` onto
 `<target8>`, `<target9>`, etc.
+
+### Plugin Tests
+
+Code that is intended to be loaded as a shared library or plugin into another
+program will often need symbols to provided by the hosting program.  In order
+to facilitate testing of such libraries, these targets can be declared to
+require "plugin tests".
+
+`<target10>`, `<target11>`, etc. will have test drivers generated as shared
+libraries instead of standalone executables (assuming they are BDE-style
+targets).  Some separate hosting program will be required to load and execute
+these tests.
 
 ## CMake
 

--- a/bdemeta/resolver.py
+++ b/bdemeta/resolver.py
@@ -99,14 +99,16 @@ class TargetResolver(Resolver[Target]):
         self._standalones               = cast(Set[str],
                                                set(config.get('standalones', [])))
         self._standalones |= {'standalones'}
-        self._virtuals: Dict[str, str]  = {}
-        self._providers: Set[str]       = set()
-        self._pkg_configs               = cast(Dict[str, str],
-                                               config.get('pkg_configs', {}))
-        self._extra_dependencies        = cast(Dict[str, List[str]],
-                                               config.get('extra_dependencies',
-                                                          {}))
-        self._incl_test_deps            = incl_test_deps
+        self._virtuals: Dict[str, str] = {}
+        self._providers: Set[str]      = set()
+        self._pkg_configs              = cast(Dict[str, str],
+                                              config.get('pkg_configs', {}))
+        self._extra_dependencies       = cast(Dict[str, List[str]],
+                                              config.get('extra_dependencies',
+                                                         {}))
+        self._plugin_tests             = cast(Set[str],
+                                              set(config.get('plugin_tests', [])))
+        self._incl_test_deps           = incl_test_deps
 
         providers = config.get('providers', {})
         assert isinstance(providers, dict)
@@ -226,6 +228,9 @@ class TargetResolver(Resolver[Target]):
 
         if any(d.name in self._runtime_libraries for d in deps):
             result.lazily_bound = True
+
+        if name in self._plugin_tests:
+            result.plugin_tests = True
 
         return result
 

--- a/bdemeta/types.py
+++ b/bdemeta/types.py
@@ -29,6 +29,7 @@ class Target:
         self.has_output               = True
         self.lazily_bound             = False
         self.overrides: Optional[str] = None
+        self.plugin_tests             = False
 
     def dependencies(self) -> Sequence['Target']:
         return self._dependencies

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 
 setup(name='bdemeta',
-      version='0.43',
+      version='0.44',
       description='Build and test BDE-style code',
       url='https://github.com/frutiger/bdemeta',
       author='Masud Rahman',

--- a/tests/cmake_parser.py
+++ b/tests/cmake_parser.py
@@ -22,10 +22,8 @@ def lex(input: TextIO) -> Iterator[Command]:
             break
         if whitespace.match(char):
             if parsing_item:
-                if parsing_command:
-                    args.append('')
-                else:
-                    command += char
+                assert(parsing_command)
+                args.append('')
             parsing_item = False
         elif char == '(':
             if parsing_command:
@@ -42,6 +40,9 @@ def lex(input: TextIO) -> Iterator[Command]:
             command, args   = '', []
             parsing_item    = False
             parsing_command = False
+        elif char == '#':
+            while char != '\n':
+                char = input.read(1)
         else:
             if parsing_command:
                 args[-1] += char

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -599,3 +599,63 @@ class LazilyBoundTest(TestCase):
         p2  = r.resolve('p2',  { 'bar': bar, 'p1': p1 })
         assert(p2.lazily_bound)
 
+class PluginTestsTest(TestCase):
+    def setUp(self):
+        self.config = {
+            'roots': [
+                P('r'),
+            ],
+            'plugin_tests': [
+                'gr2'
+            ]
+        }
+        self._patcher = OsPatcher({
+            'r': {
+                'groups': {
+                    'gr1': {
+                        'group': {
+                            'gr1.dep': '',
+                            'gr1.mem': 'gr1p1',
+                        },
+                        'gr1p1': {
+                            'package': {
+                                'gr1p1.dep': '',
+                                'gr1p1.mem': 'gr1p1_c1',
+                            },
+                            'gr1p1_c1.cpp': '',
+                            'gr1p1_c1.h': '',
+                            'gr1p1_c1.t.cpp': '',
+                        },
+                    },
+                    'gr2': {
+                        'group': {
+                            'gr2.dep': '',
+                            'gr2.mem': 'gr2p1',
+                        },
+                        'gr2p1': {
+                            'package': {
+                                'gr2p1.dep': '',
+                                'gr2p1.mem': 'gr2p1_c1',
+                            },
+                            'gr2p1_c1.cpp': '',
+                            'gr2p1_c1.h': '',
+                            'gr2p1_c1.t.cpp': '',
+                        },
+                    },
+                },
+            },
+        })
+
+    def tearDown(self):
+        self._patcher.reset()
+
+    def test_non_plugin_tests(self):
+        r   = TargetResolver(self.config)
+        gr1 = r.resolve('gr1',  {})
+        assert(not gr1.plugin_tests)
+
+    def test_plugin_tests(self):
+        r   = TargetResolver(self.config)
+        gr2 = r.resolve('gr2',  {})
+        assert(gr2.plugin_tests)
+


### PR DESCRIPTION
Add support for generating some test drivers as shared libraries,
intended to be loaded and executed as plugins in some larger hosting
program.