### PR TITLE
cmake, resolver, types: include executable component if found

### DIFF
--- a/bdemeta/cmake.py
+++ b/bdemeta/cmake.py
@@ -16,6 +16,10 @@ LIBRARY_PROLOGUE = '''\
 add_library(
     {target.name}
 '''
+EXECUTABLE_PROLOGUE = '''\
+add_executable(
+    {target.name}
+'''
 DEFINE_SYMBOL = '''\
 set_target_properties(
     {target.name} PROPERTIES
@@ -165,7 +169,10 @@ add_custom_target(
 '''
 
 def generate_bde(target: BdeTarget, out: TextIO) -> None:
-    out.write(LIBRARY_PROLOGUE.format(**locals()))
+    if target.executable:
+        out.write(EXECUTABLE_PROLOGUE.format(**locals()))
+    else:
+        out.write(LIBRARY_PROLOGUE.format(**locals()))
     for component in target.sources():
         out.write('    {}\n'.format(component).replace('\\', '/'))
     out.write(COMMAND_EPILOGUE)

--- a/bdemeta/types.py
+++ b/bdemeta/types.py
@@ -30,6 +30,7 @@ class Target:
         self.lazily_bound             = False
         self.overrides: Optional[str] = None
         self.plugin_tests             = False
+        self.executable               = False
 
     def dependencies(self) -> Sequence['Target']:
         return self._dependencies
@@ -38,10 +39,12 @@ class Package(Target):
     def __init__(self,
                  path: str,
                  dependencies: Sequence[Target],
-                 components: List[Dict[str, Optional[str]]]) -> None:
+                 components: List[Dict[str, Optional[str]]],
+                 *, executable: bool = False) -> None:
         Target.__init__(self, os.path.basename(path), dependencies)
         self._path       = path
         self._components = components
+        self.executable  = executable
 
     def includes(self) -> Iterator[str]:
         yield self._path

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -168,6 +168,13 @@ class PackageResolverTest(TestCase):
                         },
                         'a.h': '',
                     },
+                    'g1p8': {
+                        'package': {
+                            'g1p8.dep': '',
+                            'g1p8.mem': '',
+                        },
+                        'g1p8.m.cpp': '',
+                    },
                 },
                 'g2': {
                     'g2p1': {
@@ -270,6 +277,16 @@ class PackageResolverTest(TestCase):
         assert([]                               == p.dependencies())
         assert([str(P('r')/'g1'/'g1+p7')]       == list(p.includes()))
         assert([str(P('r')/'g1'/'g1+p7'/'a.h')] == list(p.headers()))
+
+    def test_one_executable_component(self):
+        r = PackageResolver(P('r')/'g1')
+        p = r.resolve('g1p8', {})
+        assert('g1p8'                                 == p.name)
+        assert([]                                     == p.dependencies())
+        assert([str(P('r')/'g1'/'g1p8')]              == list(p.includes()))
+        assert([str(P('r')/'g1'/'g1p8'/'g1p8.m.cpp')] == list(p.sources()))
+        assert([]                                     == list(p.drivers()))
+        assert(True                                   == p.executable)
 
     def test_level_two_package_has_dependency(self):
         r = PackageResolver(P('r')/'g2')

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -63,6 +63,14 @@ class TestPackage(TestCase):
         p = Package(path, ['bar'], 'baz')
         assert([path] == list(p.includes()))
 
+    def test_not_executable(self):
+        p = Package(pj('path', 'to', 'foo'), ['bar'], [])
+        assert(False == p.executable)
+
+    def test_executable(self):
+        p = Package(pj('path', 'to', 'foo'), ['bar'], [], executable=True)
+        assert(True == p.executable)
+
 class TestGroup(TestCase):
     def test_name(self):
         g = Group(pj('path', 'g'), [], [])


### PR DESCRIPTION
This allows for generating executable packages, usually found in 'applications' folder.