### PR TITLE
bdemeta, cmake, resolver: support for conan packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,10 @@ follows:
             "<root>",
             ...
         ],
+        "conan_roots": [
+            "<conan_root>",
+            ...
+        ],
         "standalones": [
             "<standalone>",
             ...
@@ -98,6 +102,11 @@ directory:
 
 The set of directories searched for standalone packages can be extended by
 specifying multiple `<standalone>` directories in the configuration.
+
+### Conan roots
+
+Conan will be relied on to provide binaries for each `<conan_root>` specified.
+`bdemeta` will not attempt to build targets that belong to these roots.
 
 #### Test-only dependencies
 

--- a/bdemeta/__main__.py
+++ b/bdemeta/__main__.py
@@ -13,15 +13,13 @@ import bdemeta.cmake
 import bdemeta.graph
 import bdemeta.resolver
 import bdemeta.testing
+from bdemeta.resolver import InvalidPathError, normalize_roots
 from bdemeta.testing import Runner
 
 class NoConfigError(RuntimeError):
     pass
 
 class InvalidArgumentsError(RuntimeError):
-    pass
-
-class InvalidPathError(RuntimeError):
     pass
 
 exec_suffix = '.exe' if sys.platform == 'win32' else ''
@@ -88,18 +86,9 @@ def make_resolver(config_path_str: str,
     except FileNotFoundError:
         raise NoConfigError(config_path)
 
-    result = []
-    for root in config['roots']:
-        path = pathlib.Path(root)
-        if path.is_absolute():
-            result.append(path)
-        else:
-            result.append(config_dir/path)
-    config['roots'] = result
-
-    for root in config['roots']:
-        if not root.is_dir():
-            raise InvalidPathError(root)
+    config['roots'] = normalize_roots(config['roots'], config_dir)
+    if 'conan_roots' in config:
+        config['conan_roots'] = normalize_roots(config['conan_roots'], config_dir)
 
     return bdemeta.resolver.TargetResolver(config,
                                            incl_test_deps,

--- a/bdemeta/cmake.py
+++ b/bdemeta/cmake.py
@@ -10,6 +10,12 @@ LISTS_PROLOGUE = '''\
 cmake_minimum_required(VERSION 3.8)
 project(bdemeta-generated-{targets[0].name})
 
+set(CONAN_BLD_INFO ${{CMAKE_BINARY_DIR}}/conanbuildinfo.cmake)
+if(EXISTS ${{CONAN_BLD_INFO}})
+    include(${{CONAN_BLD_INFO}})
+    conan_basic_setup(TARGETS)
+endif()
+
 '''
 LIBRARY_PROLOGUE = '''\
 add_library(

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 
 setup(name='bdemeta',
-      version='0.49.0',
+      version='0.50.0',
       description='Build and test BDE-style code',
       url='https://github.com/frutiger/bdemeta',
       author='Masud Rahman',

--- a/tests/test_bdemeta.py
+++ b/tests/test_bdemeta.py
@@ -193,7 +193,7 @@ class CMakeTest(TestCase):
 class MainTest(TestCase):
     def setUp(self):
         self._patcher = OsPatcher({
-            'bdemeta.json': '{"roots": ["r"]}',
+            'bdemeta.json': '{"roots": ["r", "c"], "conan_roots": ["c"]}',
             'r': {
                 'standalones': {
                     'p1': {
@@ -222,6 +222,16 @@ class MainTest(TestCase):
                     },
                 },
             },
+            'c': {
+                'standalones': {
+                    'c1': {
+                        'package': {
+                            'c1.dep': '',
+                            'c1.mem': '',
+                        },
+                    },
+                },
+            }
         })
 
     def tearDown(self):

--- a/tests/test_cmake.py
+++ b/tests/test_cmake.py
@@ -139,6 +139,7 @@ class GenerateTargetTest(TestCase):
 
         find_command(cmake, 'cmake_minimum_required')
         find_command(cmake, 'project')
+        find_command(cmake, 'conan_basic_setup')
 
     def test_empty_package_no_deps_no_test(self):
         self._test_package('target', pjoin('path', 'target'), [], [], False)


### PR DESCRIPTION
Adds optional 'conan_roots' configuration entry which overlays all the
roots that will be sourced from conan packages.